### PR TITLE
Bugfix: fields in quotation if they contain special characters

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -439,7 +439,7 @@ class NAVObjectAction {
     get fullActionTextFixed(): string {
         if (!this._prefix && !this._suffix) { return this.fullActionText };
 
-        return "action(" + StringFunctions.encloseInQuotesIfMultiWord(this.nameFixed) + ")"
+        return "action(" + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + ")"
     }
 
     constructor(fullActionText: string, objectType: string, prefix?: string, suffix?: string) {
@@ -490,7 +490,7 @@ class NAVTableField {
     get fullFieldTextFixed(): string {
         if (!this._prefix && !this._suffix) { return this.fullFieldText }
 
-        return "field(" + this.number + "; " + StringFunctions.encloseInQuotesIfMultiWord(this.nameFixed) + "; " + this.type + ")"
+        return "field(" + this.number + "; " + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + "; " + this.type + ")"
     }
 
     constructor(fullFieldText: string, objectType: string, prefix?: string, suffix?: string) {
@@ -542,7 +542,7 @@ class NAVPageField {
     get fullFieldTextFixed(): string {
         if (!this._prefix && !this._suffix) { return this.fullFieldText }
 
-        return "field(" + StringFunctions.encloseInQuotesIfMultiWord(this.nameFixed) + "; " + this.expression + ")"
+        return "field(" + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + "; " + this.expression + ")"
     }
 
     constructor(fullFieldText: string, objectType: string, prefix?: string, suffix?: string) {
@@ -593,7 +593,7 @@ class NAVPageGroup {
     get fullGroupTextFixed(): string {
         if (!this._prefix && !this._suffix) { return this.fullGroupText }
 
-        return "group(" + StringFunctions.encloseInQuotesIfMultiWord(this.nameFixed) + ")"
+        return "group(" + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + ")"
     }
 
     constructor(fullGroupText: string, objectType: string, prefix?: string, suffix?: string) {

--- a/src/StringFunctions.ts
+++ b/src/StringFunctions.ts
@@ -11,12 +11,13 @@ export class StringFunctions {
         return str.replace(/\W/g, '');
     }
 
-    static encloseInQuotesIfMultiWord(str) {
-        if (!str)
+    static encloseInQuotesIfNecessary(str) {
+        if (!str) {
             return str;
+        }
 
-        if (str.indexOf(' ') >= 0) {
-            return "\""+str+"\"";
+        if (/[^a-zA-Z0-9]/.test(str)) {
+            return "\"" + str + "\"";
         } else {
             return str;
         }


### PR DESCRIPTION
So turns out my fix for single-word field names was too quick.
Fields that contain special characters, such as No., must be in quotation as well.

#120 