### PR TITLE
Fixed statusbar error when focusing to webview

### DIFF
--- a/src/CRSFunctions.ts
+++ b/src/CRSFunctions.ts
@@ -197,12 +197,23 @@ export function HandleOnSaveTextDocument() {
     console.log('Done: HandleOnSaveTextDocument');
 }
 
+/*** changed to onDidChangeActiveTextEditor eventhandler
+ * @deprecated
+ */
 export function HandleOnOpenTextDocument() {
     console.log('Running: HandleOnOpenTextDocument');
 
     CRSStatusBar.toggleRunObjectFromStatusBar();
 
     console.log('Done: HandleOnOpenTextDocument')
+}
+
+export function HandleOnChangeActiveTextEditor(editor?: vscode.TextEditor) {
+    console.log('Running: HandleOnChangeActiveTextEditor');
+
+    CRSStatusBar.toggleRunObjectFromStatusBar(editor?.document);
+
+    console.log('Done: HandleOnChangeActiveTextEditor')
 }
 
 function getWord(editor: vscode.TextEditor): string {

--- a/src/UI/CRSStatusBar.ts
+++ b/src/UI/CRSStatusBar.ts
@@ -2,10 +2,21 @@ import * as vscode from 'vscode'
 
 export const RunObjectFromStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left,100)
 
-export function toggleRunObjectFromStatusBar(){
+export function toggleRunObjectFromStatusBar(document?: vscode.TextDocument) {
     RunObjectFromStatusBar.command = 'crs.RunCurrentObjectWeb'
 
-    let currentfile = vscode.window.activeTextEditor.document.uri;
+    let openDocument =  document || vscode.window.activeTextEditor?.document;
+    if (!openDocument) {
+        RunObjectFromStatusBar.hide();
+        return;
+    }
+
+    let currentfile = openDocument.uri;
+
+    if (!currentfile?.fsPath) {
+        RunObjectFromStatusBar.hide();
+        return;
+    }
 
     if (!currentfile.fsPath.toLowerCase().endsWith('.al')) { 
         RunObjectFromStatusBar.hide();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,9 @@ export function activate(context: vscode.ExtensionContext) { //is called when yo
     context.subscriptions.concat(commandlist, componentlist);
 
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(CRSFunctions.HandleOnSaveTextDocument));
-    context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(CRSFunctions.HandleOnOpenTextDocument));
+    // changed to onDidChangeActiveTextEditor eventhandler
+    //context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(CRSFunctions.HandleOnOpenTextDocument));
+    context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(CRSFunctions.HandleOnChangeActiveTextEditor));
 
     vscode.commands.executeCommand('crs.SetupSnippets');
 


### PR DESCRIPTION
Hi Waldo,

I have seen that your extension is subscribed to `vscode.workspace.onDidOpenTextDocument` event. This subscription causes errors when there is no active TextEditor.

### 1. A Webview is focused 
First case is no big issue as it happens rarely, but still it should be fixed. :)

### 2. No open document

Second case, however, can easily become a real performance-killer when [another extension](https://github.com/365businessdev/vscode-alxmldocumentation/blob/7f5aa97165c66408779d3fc0e4e4612073e95949/src/DoCheckDocumentation.ts#L61) decides to read up all AL files via VSCode api, thus emitting `onDidOpenTextDocument` event like 6000 times for a BaseApp.

![vscode_waldoext_error](https://user-images.githubusercontent.com/18100709/94974146-f18a0480-050d-11eb-85d9-5a21b44c1d4d.png)

### The fix
My proposed solution would be to move your statusbar update code from `workspace.onDidOpenTextDocument` to `window.onDidChangeActiveTextEditor` with some additional error checks to avoid unexpected exceptions.

It would be a big help for me, as AL Studio is currently crashing during activation phase when AL XML Documentation is present, indirectly overloading VSCode by an event subscription in your extension. Simple times indeed :)

Thanks,
Marton
