### PR TITLE
Fix-EmptyDependencyBlock

### DIFF
--- a/src/ALGraphVis.ts
+++ b/src/ALGraphVis.ts
@@ -32,6 +32,8 @@ export class ALGraphVis {
         let appName = app.name.startsWith(removePrefix) ? app.name.substr(removePrefix.length) : app.name;
         let dependencyName = dependency.name.startsWith(removePrefix) ? dependency.name.substr(removePrefix.length) : dependency.name;
 
+        if (dependencyName == '') { return };
+
         let dependencyTxt = `"${appName}" -> "${dependencyName}"`
         crsOutput.showOutput(dependencyTxt, false);
         this._graphVizText.push(dependencyTxt);

--- a/src/ALGraphVis.ts
+++ b/src/ALGraphVis.ts
@@ -24,15 +24,14 @@ export class ALGraphVis {
         if (this._workSpaceSettings[Settings.DependencyGraphExcludeAppNames].includes(dependency.name)) { return };
         if (this._workSpaceSettings[Settings.DependencyGraphExcludeAppNames].includes(app.name)) { return };
 
+        if (!dependency.TestFields) { return }; // check for empty fields
+
         if ((!this._workSpaceSettings[Settings.DependencyGraphIncludeTestApps]) && dependency.isTestApp) { return };
         if ((!this._workSpaceSettings[Settings.DependencyGraphIncludeTestApps]) && app.isTestApp) { return };
 
-
         let removePrefix = this._workSpaceSettings[Settings.DependencyGraphRemovePrefix];
         let appName = app.name.startsWith(removePrefix) ? app.name.substr(removePrefix.length) : app.name;
-        let dependencyName = dependency.name.startsWith(removePrefix) ? dependency.name.substr(removePrefix.length) : dependency.name;
-
-        if (dependencyName == '') { return };
+        let dependencyName = dependency.name.startsWith(removePrefix) ? dependency.name.substr(removePrefix.length) : dependency.name;        
 
         let dependencyTxt = `"${appName}" -> "${dependencyName}"`
         crsOutput.showOutput(dependencyTxt, false);

--- a/src/AppJsonDependency.ts
+++ b/src/AppJsonDependency.ts
@@ -59,7 +59,15 @@ export class AppJsonDependency {
     }
 
     get isMicrosoft(): boolean {
+        if (this._appJsonDependency.publisher == '') { return false }
         return (this._appJsonDependency.publisher.toLowerCase() == 'microsoft');
+    }
+
+    get TestFields(): boolean {
+        if (this.name = '') { return false };
+        if (this.publisher = '') { return false };
+
+        return true;
     }
 
 

--- a/src/AppJsonDependency.ts
+++ b/src/AppJsonDependency.ts
@@ -64,8 +64,8 @@ export class AppJsonDependency {
     }
 
     get TestFields(): boolean {
-        if (this.name = '') { return false };
-        if (this.publisher = '') { return false };
+        if (this.name == '') { return false };
+        if (this.publisher == '') { return false };
 
         return true;
     }


### PR DESCRIPTION
I have a configuration file with an empty dependency block (base file to copy to new apps) - when I run "Create GraphViz Dependency Graph" I get the error "Command 'CRS: Create GraphViz Dependency Graph' resulted in an error (Cannot read property 'toLowerCase' of undefined)".

I don't know how to test my own changes (deploy a test version to vscode?) but I believe this code fixes this issue - please review :)

https://i.imgur.com/sDEVQkx.png