### PR TITLE
Best-practice file naming configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "onCommand:crs.CreateGraphVizDependencyGraph",
         "onCommand:crs.SearchMicrosoftDocs",
         "onCommand:crs.SearchGoogle",
-        "onCommand:crs.SearchObjectNames"
+        "onCommand:crs.SearchObjectNames",
+        "onCommand:crs.ConfigureBestPracticeNaming"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -121,6 +122,10 @@
             {
                 "command": "crs.SearchObjectNames",
                 "title": "CRS: Search Object Names"
+            },
+            {
+                "command": "crs.ConfigureBestPracticeNaming",
+                "title": "CRS: Configure Best-practice File Naming"
             }
         ],
         "configuration": {

--- a/src/CRSFunctions.ts
+++ b/src/CRSFunctions.ts
@@ -10,6 +10,7 @@ import { MSDocs } from './MSDocs';
 import { Google } from './Google';
 import * as CRSStatusBar from './UI/CRSStatusBar';
 import * as crsOutput from './CRSOutput';
+import * as Configuration from './Configuration';
 
 
 
@@ -244,6 +245,14 @@ export function HandleOnChangeActiveTextEditor(editor?: vscode.TextEditor) {
     CRSStatusBar.toggleRunObjectFromStatusBar(editor?.document);
 
     console.log('Done: HandleOnChangeActiveTextEditor')
+}
+
+export function ConfigureBestPracticeNaming() {
+    console.log('Running: ConfigureBestPracticeNaming');
+
+    Configuration.configureBestPracticesNaming();
+
+    console.log('Done: ConfigureBestPracticeNaming')
 }
 
 function getWord(editor: vscode.TextEditor): string {

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+
+export function configureBestPracticesNaming() {
+    const items: vscode.QuickPickItem[] = [];
+    const uriMap: any[] = [];
+
+    function addPick(label: string, description: string, uri: any) {
+        uriMap.push(uri);
+        items.push({ label, description });
+    }
+
+    addPick('User', 'User configuration (applies to all workspaces)', vscode.ConfigurationTarget.Global);
+    if (vscode.workspace.name) {
+        let file = vscode.workspace['workspaceFile'];
+        if (file) {
+            addPick(vscode.workspace.name, file.path, vscode.ConfigurationTarget.Workspace);
+            for (let folder of vscode.workspace.workspaceFolders) {
+                addPick(folder.name, `${folder.uri.path}/.vscode/settings.json`, folder.uri);
+            }
+        } else {
+            addPick('Workspace', `${vscode.workspace.workspaceFolders[0].uri.path}/.vscode/settings.json`, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+    }
+
+    vscode.window.showQuickPick(items, { placeHolder: 'Where would you like to configure the best-practice naming configuration?' })
+        .then(choice => {
+            if (!choice) {
+                return;
+            }
+
+            let index = items.indexOf(choice);
+            let uri = uriMap[index];
+            let updateTarget = index === 0 || undefined; // undefined is necessary here! Leaving it at false would always update Workspace.
+            let config = vscode.workspace.getConfiguration('CRS', uri);
+            config.update('FileNamePattern', '<ObjectNameShort>.<ObjectTypeShortPascalCase>.al', updateTarget);
+            config.update('FileNamePatternExtensions', '<ObjectNameShort>.<ObjectTypeShortPascalCase>.al', updateTarget);
+            config.update('FileNamePatternPageCustomizations', '<ObjectNameShort>.<ObjectTypeShortPascalCase>.al', updateTarget);
+        });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,8 @@ export function activate(context: vscode.ExtensionContext) { //is called when yo
         vscode.commands.registerCommand('crs.SearchObjectNames', CRSFunctions.SearchObjectNames),
 
         vscode.commands.registerCommand('crs.SetupSnippets', CRSFunctions.SetupSnippets),
+
+        vscode.commands.registerCommand('crs.ConfigureBestPracticeNaming', CRSFunctions.ConfigureBestPracticeNaming)
     ];
 
     let componentlist = [


### PR DESCRIPTION
Contributed command to configure best-practice file naming in user,
workspace, or individual workspace folder settings file, depending on
current workspace configuration.

The command sets the `FileNamePattern*` options as explained in
https://www.waldo.be/2020/04/03/how-to-really-rename-all-al-files-of-your-business-central-app/