### PR TITLE
Reuse crs terminal if one already exists

### DIFF
--- a/src/CRSTerminal.ts
+++ b/src/CRSTerminal.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-
-export const Terminal = vscode.window.createTerminal('crs');
+import { Terminal } from './extension';
 
 export function GitMove(from: string, to: string) {
     Terminal.sendText(`git mv ${from} ${to}`);
@@ -26,4 +25,15 @@ export function CompileDGML(alcpath: string, projectpath: string, packagecachepa
     Terminal.sendText(`Set-Location $Temp`);
 
     Terminal.show();
+}
+
+export function GetTerminal(terminalName: string = 'crs'): vscode.Terminal {
+    const terminals = vscode.window.terminals.filter(element => element.name === terminalName);
+    
+    if (terminals.length > 0) {
+        return terminals.shift()!;
+    }
+    else {
+        return vscode.window.createTerminal(terminalName);
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,9 @@ import * as vscode from 'vscode';  //VS Code extensibility API
 import * as CRSFunctions from './CRSFunctions';  //Our own functions
 import { CRSExtensionPublicApi } from './api/CRSExtensionPublicApi';
 import * as CRSStatusBar from './UI/CRSStatusBar';
+import { GetTerminal } from './CRSTerminal';
+
+export const Terminal: vscode.Terminal = GetTerminal();
 
 export function activate(context: vscode.ExtensionContext) { //is called when your extension is activated (when command is executed)
 


### PR DESCRIPTION
VS Code now preserves terminals between reloads of the window.

The extension creates a new crs terminal each time the window is loaded so you can collect a stack of crs terminals.

![image](https://user-images.githubusercontent.com/19267298/126504246-88c59996-daed-43b8-a634-4be9f54bc907.png)
