### PR TITLE
Hide ampersand from the commandline

### DIFF
--- a/src/DynamicsNAV.ts
+++ b/src/DynamicsNAV.ts
@@ -111,11 +111,11 @@ export class DynamicsNAV {
                 break;
             case 'Firefox':
                 runURL = workspacesettings[Settings.Incognito] == true ? '-private-window ' + runURL : runURL;
-                exec(`start firefox ${runURL}`, { shell: 'cmd.exe' });
+                exec(`start firefox "${runURL}"`, { shell: 'cmd.exe' });
                 break;
             case 'Chrome':
                 runURL = workspacesettings[Settings.Incognito] == true ? '-incognito ' + runURL : runURL;
-                exec(`start chrome ${runURL}`, { shell: 'cmd.exe' });
+                exec(`start chrome "${runURL}"`, { shell: 'cmd.exe' });
                 vscode.window.showWarningMessage('Running an object in Chrome might not work.  Use Edge instead (you can set al.Browser setting to Edge (in User Settings)).')
                 break;
             default:


### PR DESCRIPTION
If running a container as multitenant, you get a URL in the format BASE/?tenant=xyz&table=1234

But the command line does not like the ampersand and thus does not work in my chrome, it only opens the base including the tenant thus skipping the rest of the URL. By wrapping the URL in double quotes, the URL is only seen as a string, with or without ampersand.

Hope it will render useful, same applies to Firefox