### PR TITLE
Search workspace folder for config files

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -71,7 +71,9 @@ export class Settings {
             vscode.workspace.getConfiguration(this.WORKSPACEKEY, ResourceUri) :
             vscode.window.activeTextEditor ?
                 vscode.workspace.getConfiguration(this.WORKSPACEKEY, vscode.window.activeTextEditor.document.uri) :
-                vscode.workspace.getConfiguration(this.WORKSPACEKEY, null);
+                vscode.workspace.workspaceFolders ? 
+                    vscode.workspace.getConfiguration(this.WORKSPACEKEY, vscode.workspace.workspaceFolders[0].uri) :
+                    vscode.workspace.getConfiguration(this.WORKSPACEKEY, null);
 
         this.SettingCollection[this.NstFolder] = this.getSetting(this.NstFolder);
         this.SettingCollection[this.ManagementModule] = this.joinPaths([this.SettingCollection[this.NstFolder], this.MANAGEMENTDLL]);


### PR DESCRIPTION
Fixes #195 

If we are using the file wizard from [al-code-outline](https://github.com/anzwdev/al-code-outline) and we are working with a workspace the settings inside the .vscode/settings.json are not taken into account.

PS: I would have expected ``vscode.workspace.getConfiguration(this.WORKSPACEKEY, null);`` to retrieve all merged configurations by default, not just the default values.