### PR TITLE
Added option for skipping warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,16 +460,16 @@
         "simple-git": "^1.110.0"
     },
     "devDependencies": {
+        "@types/vscode": "^1.28.0",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^14.18.12",
-        "@types/vscode": "^1.28.0",
+        "@types/node": "14.x",
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
-        "@vscode/test-electron": "^2.0.3",
         "eslint": "^8.6.0",
         "glob": "^7.2.0",
         "mocha": "^9.1.3",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.4",
+        "@vscode/test-electron": "^2.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -302,6 +302,12 @@
                     "type": "string",
                     "description": "Remove this prefix from the appname in the graph.  Remark: this has no influence on the 'Exluce AppNames' setting.",
                     "scope": "resource"
+                },
+                "CRS.SkipWarningMessageOnRenameAll": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to skip the warning message when renaming all files from all opened workspaces.",
+                    "scope": "resource"
                 }
             }
         },
@@ -454,16 +460,16 @@
         "simple-git": "^1.110.0"
     },
     "devDependencies": {
-        "@types/vscode": "^1.28.0",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.0.0",
-        "@types/node": "14.x",
+        "@types/node": "^14.18.12",
+        "@types/vscode": "^1.28.0",
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
+        "@vscode/test-electron": "^2.0.3",
         "eslint": "^8.6.0",
         "glob": "^7.2.0",
         "mocha": "^9.1.3",
-        "typescript": "^4.5.4",
-        "@vscode/test-electron": "^2.0.3"
+        "typescript": "^4.5.4"
     }
 }

--- a/src/CRSFunctions.ts
+++ b/src/CRSFunctions.ts
@@ -156,13 +156,23 @@ export function RenameCurrentFile() {
 export function RenameAllFiles() {
     console.log('Running: RenameAllFiles');
 
-    vscode.window.showWarningMessage('Are you sure to rename all files from all opened workspaces?', 'Yes', 'No').then((action: String) => {
-        if (action === 'Yes') {
-            WorkspaceFiles.RenameAllFiles();
-            vscode.commands.executeCommand('workbench.action.closeAllEditors');
-        }
-    });
+    let mySettings = Settings.GetConfigSettings(null);
+    let SkipWarningMessageOnRenameAll = mySettings[Settings.SkipWarningMessageOnRenameAll];
 
+    if (!SkipWarningMessageOnRenameAll) {
+        vscode.window.showWarningMessage('Are you sure to rename all files from all opened workspaces?', 'Yes', 'No').then((action: String) => {
+            if (action === 'Yes') {
+                WorkspaceFiles.RenameAllFiles();
+                vscode.commands.executeCommand('workbench.action.closeAllEditors');
+            }
+        });
+    }
+    else
+    {
+        WorkspaceFiles.RenameAllFiles();
+        vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    }
+    
     console.log('Done: RenameAllFiles')
 }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -37,6 +37,8 @@ export class Settings {
     static readonly Incognito = 'incognito';
     static readonly packageCachePath = 'packageCachePath';
 
+    static readonly SkipWarningMessageOnRenameAll = 'SkipWarningMessageOnRenameAll';
+
     static readonly SearchObjectNamesRegexPattern = 'SearchObjectNamesRegexPattern';
 
     static readonly AlSubFolderName = 'AlSubFolderName';
@@ -101,6 +103,7 @@ export class Settings {
         this.SettingCollection[this.DependencyGraphExcludeAppNames] = this.getSetting(this.DependencyGraphExcludeAppNames);
         this.SettingCollection[this.DependencyGraphExcludePublishers] = this.getSetting(this.DependencyGraphExcludePublishers);
         this.SettingCollection[this.DependencyGraphRemovePrefix] = this.getSetting(this.DependencyGraphRemovePrefix);
+        this.SettingCollection[this.SkipWarningMessageOnRenameAll] = this.getSetting(this.SkipWarningMessageOnRenameAll);
 
         this.getConfigSettingsAL(ResourceUri);
     }


### PR DESCRIPTION
When CRS Rename all files is run a question "Are you sure to rename all files from all opened workspaces?" pops up, which is disturbing the custom created visual studio task for compiling the app with all the checks done.

This feature gives the user the possibility to disable this question popup.