### PR TITLE
Added Log Message snippet

### DIFF
--- a/snippets/al.json
+++ b/snippets/al.json
@@ -45,5 +45,12 @@
             "",
             "${0}"
         ]
+    },
+    "Snippet (waldo): Log Message": {
+        "description": "Snippet (waldo): Log Message",
+        "prefix": "tLogMessageWaldo",
+        "body": [
+            "Session.LogMessage('${1:Add Event ID}', ${2:AddMessageVariable}, Verbosity::${3|Normal,Critical,Error,Verbose,Warning|}, DataClassification::${4|SystemMetadata,AccountData,CustomerContent,EndUserIdentifiableInformation,EndUserPseudonymousIdentifiers,OrganizationIdentifiableInformation,ToBeClassified|}, TelemetryScope::${5|ExtensionPublisher,All|}, 'Category', ${6:AddValueVariable});"
+        ]
     }
 }


### PR DESCRIPTION
This PR attempts to close https://github.com/waldo1001/crs-al-language-extension/issues/236.

I'd also like to point 3 things out here:

1. `Verbosity::${3|Normal,Critical,Error,Verbose,Warning|}`
2. `DataClassification::${4|SystemMetadata,AccountData,CustomerContent,EndUserIdentifiableInformation,EndUserPseudonymousIdentifiers,OrganizationIdentifiableInformation,ToBeClassified|}`
3. `TelemetryScope::${5|ExtensionPublisher,All|}`

The order has been customized in a way that they now start with Normal, SystemMetadata and ExtensionPublisher. This depends on the scenario - so... shall we put it out there as it is and let the users test it? wdyt