### PR TITLE
Hotfix for #245

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,7 +3,6 @@
 .vscode-test/**
 src/**
 test/**
-node_modules
 .eslintrc.json
 .gitattributes
 .gitignore


### PR DESCRIPTION
Remove `node_modules` from `.vscodeignore`