### PR TITLE
First draft for Support of multiple Prefixes

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -300,7 +300,7 @@ export class NAVObject {
         var reg = NAVTableField.fieldRegEx();
         var result;
         while ((result = reg.exec(this.NAVObjectText)) !== null) {
-            this.tableFields.push(new NAVTableField(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNameSuffix]))
+            this.tableFields.push(new NAVTableField(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNamePrefixes], this._workSpaceSettings[Settings.ObjectNameSuffix]))
         }
 
         var reg = NAVPageField.fieldRegEx();
@@ -548,6 +548,7 @@ class NAVTableField {
     public type: string;
     private _objectType: string;
     private _prefix: string;
+    private _prefixes: string[];
     private _suffix: string;
 
     public static fieldRegEx(): RegExp {
@@ -555,12 +556,24 @@ class NAVTableField {
     }
 
     get nameFixed(): string {
-        if (!this._prefix && !this._suffix) { return this.name }
+        if (!this._prefix && !this._suffix && !this._prefixes) { return this.name }
         if (!this._objectType.toLocaleLowerCase().endsWith('extension')) { return this.name }; //only for extensionobjects
 
         let result = this.name
         if (this._prefix && !this.name.startsWith(this._prefix)) {
             result = this._prefix + result
+        }
+        if (!this._prefix && this._prefixes) {
+            var addPrefix = true;
+            this._prefixes.forEach(prefix => {
+                if (this.name.startsWith(prefix))
+                {
+                    addPrefix = false;
+                }
+            });
+            if (addPrefix) {
+                result = this._prefixes[0] + result
+            }
         }
         if (this._suffix && !this.name.endsWith(this._suffix)) {
             result = result + this._suffix
@@ -569,14 +582,15 @@ class NAVTableField {
     }
 
     get fullFieldTextFixed(): string {
-        if (!this._prefix && !this._suffix) { return this.fullFieldText }
+        if (!this._prefix && !this._suffix && !this._prefixes) { return this.fullFieldText }
 
         return "field(" + this.number + "; " + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + "; " + this.type + ")"
     }
 
-    constructor(fullFieldText: string, objectType: string, prefix?: string, suffix?: string) {
+    constructor(fullFieldText: string, objectType: string, prefix?: string, prefixes?: string[], suffix?: string) {
         this.fullFieldText = fullFieldText;
         this._prefix = prefix ? prefix : null;
+        this._prefixes = prefixes ? prefixes : null;
         this._suffix = suffix ? suffix : null;
         this._objectType = objectType;
 

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -300,7 +300,7 @@ export class NAVObject {
         var reg = NAVTableField.fieldRegEx();
         var result;
         while ((result = reg.exec(this.NAVObjectText)) !== null) {
-            this.tableFields.push(new NAVTableField(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNamePrefixes], this._workSpaceSettings[Settings.ObjectNameSuffix]))
+            this.tableFields.push(new NAVTableField(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNameSuffix], this._workSpaceSettings[Settings.MandatoryAffixes]))
         }
 
         var reg = NAVPageField.fieldRegEx();
@@ -318,7 +318,7 @@ export class NAVObject {
         var reg = NAVReportColumn.columnRegEx();
         var result;
         while ((result = reg.exec(this.NAVObjectText)) !== null) {
-            this.reportColumns.push(new NAVReportColumn(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNameSuffix]))
+            this.reportColumns.push(new NAVReportColumn(result[1], this.objectType, this._workSpaceSettings[Settings.ObjectNamePrefix], this._workSpaceSettings[Settings.ObjectNameSuffix], this._workSpaceSettings[Settings.MandatoryAffixes]))
         }
 
         this.NAVObjectText = initNAVObjectText;
@@ -548,7 +548,7 @@ class NAVTableField {
     public type: string;
     private _objectType: string;
     private _prefix: string;
-    private _prefixes: string[];
+    private _affixes: string[];
     private _suffix: string;
 
     public static fieldRegEx(): RegExp {
@@ -556,24 +556,26 @@ class NAVTableField {
     }
 
     get nameFixed(): string {
-        if (!this._prefix && !this._suffix && !this._prefixes) { return this.name }
+        if (!this._prefix && !this._suffix && !this.hasAffixesDefined()) { return this.name }
         if (!this._objectType.toLocaleLowerCase().endsWith('extension')) { return this.name }; //only for extensionobjects
-
-        let result = this.name
-        if (this._prefix && !this.name.startsWith(this._prefix)) {
-            result = this._prefix + result
-        }
-        if (!this._prefix && this._prefixes) {
-            var addPrefix = true;
-            this._prefixes.forEach(prefix => {
-                if (this.name.startsWith(prefix))
+        
+        if (this.hasAffixesDefined()) {
+            var affixNeeded = true;
+            this._affixes.forEach(affix => {
+                if (this.name.startsWith(affix) || this.name.endsWith(affix))
                 {
-                    addPrefix = false;
+                    affixNeeded = false;
+                    return
                 }
             });
-            if (addPrefix) {
-                result = this._prefixes[0] + result
+            if (!affixNeeded) {                
+                return this.name;
             }
+        }
+
+        let result = this.name;
+        if (this._prefix && !this.name.startsWith(this._prefix)) {
+            result = this._prefix + result
         }
         if (this._suffix && !this.name.endsWith(this._suffix)) {
             result = result + this._suffix
@@ -582,16 +584,16 @@ class NAVTableField {
     }
 
     get fullFieldTextFixed(): string {
-        if (!this._prefix && !this._suffix && !this._prefixes) { return this.fullFieldText }
+        if (!this._prefix && !this._suffix && !this.hasAffixesDefined()) { return this.fullFieldText }
 
         return "field(" + this.number + "; " + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + "; " + this.type + ")"
     }
 
-    constructor(fullFieldText: string, objectType: string, prefix?: string, prefixes?: string[], suffix?: string) {
+    constructor(fullFieldText: string, objectType: string, prefix?: string, suffix?: string, affixes?: string[]) {
         this.fullFieldText = fullFieldText;
         this._prefix = prefix ? prefix : null;
-        this._prefixes = prefixes ? prefixes : null;
         this._suffix = suffix ? suffix : null;
+        this._affixes = affixes ? affixes : null;
         this._objectType = objectType;
 
         this.parseFieldText();
@@ -605,6 +607,11 @@ class NAVTableField {
             this.name = result[3].trim().toString();
             this.type = result[4].trim().toString();
         }
+    } 
+    
+    private hasAffixesDefined() : boolean
+    {
+        return (Array.isArray(this._affixes) && this._affixes.length > 0 )
     }
 }
 
@@ -718,6 +725,7 @@ class NAVReportColumn {
     private _objectType: string;
     private _prefix: string;
     private _suffix: string;
+    private _affixes: string[];
 
     public static columnRegEx(): RegExp {
         // return /.*(column\( *"?([ a-zA-Z0-9._/&%\/()-]+)"? *; *([" a-zA-Z0-9._/&%\/()-]+) *\))/g;
@@ -725,8 +733,22 @@ class NAVReportColumn {
     }
 
     get nameFixed(): string {
-        if (!this._prefix && !this._suffix) { return this.name }
+        if (!this._prefix && !this._suffix && !this.hasAffixesDefined()) { return this.name }
         if (!this._objectType.toLocaleLowerCase().endsWith('extension')) { return this.name }; //only for extensionobjects
+
+        if (this.hasAffixesDefined()) {
+            var affixNeeded = true;
+            this._affixes.forEach(affix => {
+                if (this.name.startsWith(affix) || this.name.endsWith(affix))
+                {
+                    affixNeeded = false;
+                    return
+                }
+            });
+            if (!affixNeeded) {                
+                return this.name;
+            }
+        }
 
         let result = this.name
         if (this._prefix && !this.name.startsWith(this._prefix.replace(" ", ""))) {
@@ -740,15 +762,16 @@ class NAVReportColumn {
     }
 
     get fullColumnTextFixed(): string {
-        if (!this._prefix && !this._suffix) { return this.fullColumnText }
+        if (!this._prefix && !this._suffix && !this.hasAffixesDefined()) { return this.fullColumnText }
 
         return "column(" + StringFunctions.encloseInQuotesIfNecessary(this.nameFixed) + "; " + this.expression + ")"
     }
 
-    constructor(fullColumnText: string, objectType: string, prefix?: string, suffix?: string) {
+    constructor(fullColumnText: string, objectType: string, prefix?: string, suffix?: string, affixes?: string[]) {
         this.fullColumnText = fullColumnText;
         this._prefix = prefix ? prefix : null;
         this._suffix = suffix ? suffix : null;
+        this._affixes = affixes ? affixes : null;
         this._objectType = objectType;
 
         this.parseColumnText();
@@ -761,6 +784,11 @@ class NAVReportColumn {
             this.name = result[2].trim().toString();
             this.expression = result[3].trim().toString();
         }
+    }
+    
+    private hasAffixesDefined() : boolean
+    {
+        return (Array.isArray(this._affixes) && this._affixes.length > 0 )
     }
 
 }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -27,7 +27,6 @@ export class Settings {
     static readonly FileNamePatternPageCustomizations = 'FileNamePatternPageCustomizations';
     static readonly OnSaveAlFileAction = 'OnSaveAlFileAction';
     static readonly ObjectNamePrefix = 'ObjectNamePrefix';
-    static readonly ObjectNamePrefixes = 'ObjectNamePrefixes';
     static readonly ObjectNameSuffix = 'ObjectNameSuffix';
     static readonly RemovePrefixFromFilename = 'RemovePrefixFromFilename';
     static readonly RemoveSuffixFromFilename = 'RemoveSuffixFromFilename';
@@ -51,6 +50,7 @@ export class Settings {
     static readonly DependencyGraphExcludePublishers = 'DependencyGraph.ExcludePublishers';
     static readonly DependencyGraphRemovePrefix = 'DependencyGraph.RemovePrefix';
 
+    static readonly MandatoryAffixes = 'AppSourceCop.MandatoryAffixes';
 
     private static config: vscode.WorkspaceConfiguration;
     private static launchconfig: vscode.WorkspaceConfiguration;
@@ -90,7 +90,6 @@ export class Settings {
         this.SettingCollection[this.FileNamePatternExtensions] = this.getSetting(this.FileNamePatternExtensions);
         this.SettingCollection[this.FileNamePatternPageCustomizations] = this.getSetting(this.FileNamePatternPageCustomizations);
         this.SettingCollection[this.ObjectNamePrefix] = this.getSetting(this.ObjectNamePrefix);
-        this.SettingCollection[this.ObjectNamePrefixes] = this.getSetting(this.ObjectNamePrefixes);
         this.SettingCollection[this.ObjectNameSuffix] = this.getSetting(this.ObjectNameSuffix);
         this.SettingCollection[this.RemovePrefixFromFilename] = this.getSetting(this.RemovePrefixFromFilename);
         this.SettingCollection[this.RemoveSuffixFromFilename] = this.getSetting(this.RemoveSuffixFromFilename);
@@ -150,16 +149,35 @@ export class Settings {
         this.SettingCollection[this.SandboxName] = currentLaunchConfig[0].sandboxName;
     }
 
+    private static getAppSourceCopSettings(ResourceUri: vscode.Uri) {
+        let appSourceCopSettings = ResourceUri ?
+            require(join(vscode.workspace.getWorkspaceFolder(ResourceUri).uri.fsPath, "AppSourceCop.json")) :
+            vscode.window.activeTextEditor ?
+                require(join(vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath, "AppSourceCop.json")) :
+                vscode.workspace.workspaceFolders ?
+                require(join(vscode.workspace.workspaceFolders[0].uri.fsPath, "AppSourceCop.json")): null;
+        if (appSourceCopSettings) {
+            this.SettingCollection[this.MandatoryAffixes] = appSourceCopSettings.mandatoryAffixes
+        }
+    }
+
     public static GetAllSettings(ResourceUri: vscode.Uri) {
         this.getConfigSettings(ResourceUri);
         this.getAppSettings(ResourceUri);
         this.getLaunchSettings(ResourceUri);
+        this.getAppSourceCopSettings(ResourceUri);
 
         return this.SettingCollection;
     }
 
     public static GetAppSettings(ResourceUri: vscode.Uri) {
         this.getAppSettings(ResourceUri);
+
+        return this.SettingCollection;
+    }
+
+    public static GetAppSourceCopSettings(ResourceUri: vscode.Uri) {
+        this.getAppSourceCopSettings(ResourceUri);
 
         return this.SettingCollection;
     }
@@ -172,6 +190,8 @@ export class Settings {
 
     public static GetConfigSettings(ResourceUri: vscode.Uri) {
         this.getConfigSettings(ResourceUri);
+        //TODO: How to integrate AppSourceCopSettings into NAVObject?
+        this.getAppSourceCopSettings(ResourceUri);
 
         return this.SettingCollection;
     }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -27,6 +27,7 @@ export class Settings {
     static readonly FileNamePatternPageCustomizations = 'FileNamePatternPageCustomizations';
     static readonly OnSaveAlFileAction = 'OnSaveAlFileAction';
     static readonly ObjectNamePrefix = 'ObjectNamePrefix';
+    static readonly ObjectNamePrefixes = 'ObjectNamePrefixes';
     static readonly ObjectNameSuffix = 'ObjectNameSuffix';
     static readonly RemovePrefixFromFilename = 'RemovePrefixFromFilename';
     static readonly RemoveSuffixFromFilename = 'RemoveSuffixFromFilename';
@@ -89,6 +90,7 @@ export class Settings {
         this.SettingCollection[this.FileNamePatternExtensions] = this.getSetting(this.FileNamePatternExtensions);
         this.SettingCollection[this.FileNamePatternPageCustomizations] = this.getSetting(this.FileNamePatternPageCustomizations);
         this.SettingCollection[this.ObjectNamePrefix] = this.getSetting(this.ObjectNamePrefix);
+        this.SettingCollection[this.ObjectNamePrefixes] = this.getSetting(this.ObjectNamePrefixes);
         this.SettingCollection[this.ObjectNameSuffix] = this.getSetting(this.ObjectNameSuffix);
         this.SettingCollection[this.RemovePrefixFromFilename] = this.getSetting(this.RemovePrefixFromFilename);
         this.SettingCollection[this.RemoveSuffixFromFilename] = this.getSetting(this.RemoveSuffixFromFilename);

--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -166,6 +166,26 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(field.name.startsWith(testSettings[Settings.ObjectNamePrefix]), true)
         })
     });
+    test("Tableextension - set prefixes to fields", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.ObjectNamePrefixes] = ['waldo'];
+
+        let navTestObject = NAVTestObjectLibrary.getTableExtensionWrongFileNameAndKeyWord();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        assert.strictEqual(navObject.tableFields[0].nameFixed, testSettings[Settings.ObjectNamePrefixes][0] + navObject.tableFields[0].name)
+        assert.strictEqual(navObject.tableFields[0].nameFixed.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
+        assert.strictEqual(navObject.tableFields.length, 5) //has 5 fields 
+        navObject.tableFields.forEach(field => {
+            assert.strictEqual(field.nameFixed.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
+        })
+
+        //check result text that would be saved to file
+        let navObject2 = new NAVObject(navObject.NAVObjectTextFixed, testSettings, navTestObject.ObjectFileName)
+        navObject2.tableFields.forEach(field => {
+            assert.strictEqual(field.name.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
+        })
+    });
     test("Tableextension - skip setting prefix to fields", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNamePrefix] = 'waldo';

--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -166,26 +166,6 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(field.name.startsWith(testSettings[Settings.ObjectNamePrefix]), true)
         })
     });
-    test("Tableextension - set prefixes to fields", () => {
-        let testSettings = Settings.GetConfigSettings(null)
-        testSettings[Settings.ObjectNamePrefixes] = ['waldo'];
-
-        let navTestObject = NAVTestObjectLibrary.getTableExtensionWrongFileNameAndKeyWord();
-        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
-
-        assert.strictEqual(navObject.tableFields[0].nameFixed, testSettings[Settings.ObjectNamePrefixes][0] + navObject.tableFields[0].name)
-        assert.strictEqual(navObject.tableFields[0].nameFixed.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
-        assert.strictEqual(navObject.tableFields.length, 5) //has 5 fields 
-        navObject.tableFields.forEach(field => {
-            assert.strictEqual(field.nameFixed.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
-        })
-
-        //check result text that would be saved to file
-        let navObject2 = new NAVObject(navObject.NAVObjectTextFixed, testSettings, navTestObject.ObjectFileName)
-        navObject2.tableFields.forEach(field => {
-            assert.strictEqual(field.name.startsWith(testSettings[Settings.ObjectNamePrefixes][0]), true)
-        })
-    });
     test("Tableextension - skip setting prefix to fields", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNamePrefix] = 'waldo';
@@ -224,6 +204,30 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(field.name.endsWith(testSettings[Settings.ObjectNameSuffix]), true)
         })
     });
+    
+    
+    test("Tableextension - Don't set double Affix", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.ObjectNamePrefix] = 'waldo';
+        testSettings[Settings.MandatoryAffixes] = ['waldo'];
+
+        let navTestObject = NAVTestObjectLibrary.getTableExtensionWithSuffix();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        assert.notStrictEqual(navObject.tableFields.length, 0)
+
+        let navObject2 = new NAVObject(navObject.NAVObjectTextFixed, testSettings, navTestObject.ObjectFileName)
+        navObject2.tableFields.forEach(tableField => {
+            assert.strictEqual(tableField.name.endsWith(testSettings[Settings.MandatoryAffixes][0]), true);
+            assert.strictEqual(tableField.name, tableField.nameFixed);
+        })
+
+        for (let i = 0; i < navObject2.tableFields.length; i++) {
+            assert.strictEqual(navObject2.tableFields[i].name, navObject.tableFields[i].name)
+        }
+    });
+
+
     test("Tableextension - Don't change fieldnumber", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNameSuffix] = 'waldo';
@@ -365,6 +369,28 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(navObject2.reportColumns[i].name, navObject.reportColumns[i].name)
         }
     });
+    
+    test("Reportextension - Don't set double Affix", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.ObjectNamePrefix] = 'waldo';
+        testSettings[Settings.MandatoryAffixes] = ['waldo'];
+
+        let navTestObject = NAVTestObjectLibrary.getReportExtensionWithSuffix();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        assert.notStrictEqual(navObject.reportColumns.length, 0)
+
+        let navObject2 = new NAVObject(navObject.NAVObjectTextFixed, testSettings, navTestObject.ObjectFileName)
+        navObject2.reportColumns.forEach(column => {
+            assert.strictEqual(column.name.endsWith(testSettings[Settings.MandatoryAffixes][0]), true);
+            assert.strictEqual(column.name, column.nameFixed);
+        })
+
+        for (let i = 0; i < navObject2.reportColumns.length; i++) {
+            assert.strictEqual(navObject2.reportColumns[i].name, navObject.reportColumns[i].name)
+        }
+    });
+
     test("Reportextension - Fields on request page", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNameSuffix] = 'waldo';

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -482,6 +482,25 @@ export function getTableExtension(): NAVTestObject {
     return object;
 }
 
+
+export function getTableExtensionWithSuffix(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'SomeTableExt.al'
+    object.ObjectText = `tableextension 50006 "Sales Cr.Memo Header waldo" extends "Sales Cr.Memo Header"
+    {
+        fields
+        {
+            field(50021; "Test Fieldwaldo "; Code[20])
+            {
+                Caption = 'Test Field';
+                DataClassification = CustomerContent;
+            }        
+    }
+    `
+    return object;
+}
+
 export function getTableExtensionWithSkippingFieldForRename(): NAVTestObject {
     let object = new NAVTestObject;
 


### PR DESCRIPTION
This is a first draft to support multiple prefixes.

Right now I added the feature only for table extensions fields.
But this can easily added for the other extension objects.

I was tryin to create a solution for issue: https://github.com/waldo1001/crs-al-language-extension/issues/151

It's not perfect, but I could work as temporary solution.

@waldo1001 do you have any plans and time to work on improvements of prefix handling or would accept the solution that is proposed with this Pull Request.

@christianbraeunlich you do seem to have some experience with npm.
Do you know how I can disable that the yarn.lock is updated and that yarn.lock is used instead of package-lock.json for this repository?