### PR TITLE
:sparkles: Add Support for Arrays in Report Columns

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -500,7 +500,7 @@ class NAVObjectAction {
     private _objectType: string;
 
     public static actionRegEx(): RegExp {
-        return /.*( (action\("?)([ a-zA-Z0-9._/&-]+)"?\))/g
+        return /.*( (action\("?)([ a-zA-Z0-9._/&-]+(\[([1-9]\d*)\])?)"?\))/g
     }
 
     get nameFixed(): string {

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -931,6 +931,14 @@ export function getSimpleReportExtension(): NAVTestObject {
                 {
     
                 }
+                column(APO_YourReference4; CustomerAddr[1])
+                {
+    
+                }
+                column(APO_YourReference5; CustomerAddr[10])
+                {
+    
+                }
             }
         }
     
@@ -973,6 +981,14 @@ export function getReportExtensionWithSuffix(): NAVTestObject {
     
                 }
                 column(APO_YourReference3waldo; YourReference)
+                {
+    
+                }
+                column(APO_YourReference4; CustomerAddr[1])
+                {
+    
+                }
+                column(APO_YourReference5; CustomerAddr[10])
                 {
     
                 }


### PR DESCRIPTION
It is very common to use array values in Report Columns. To Support adding of a prefix. I updated the Regex for Report Columns