### PR TITLE
#260 Add Support for Arrays on Page Extensions

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -603,7 +603,7 @@ class NAVPageField {
     private _suffix: string;
 
     public static fieldRegEx(): RegExp {
-        return /.*(field\( *"?([ a-zA-Z0-9._/&%\/()-]+)"? *; *([" a-zA-Z0-9._/&%\/()-]+(\[([1-9]\d*)\])?) *\))/g;        
+        return /.*(field\( *"?([ a-zA-Z0-9._/&%\/()-]+)"? *; *([" a-zA-Z0-9._/&%\/()-]+(\[([1-9]\d*)\])?) *\))/g; 
     }
 
     get nameFixed(): string {

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -603,7 +603,7 @@ class NAVPageField {
     private _suffix: string;
 
     public static fieldRegEx(): RegExp {
-        return /.*(field\( *"?([ a-zA-Z0-9._/&%\/()-]+)"? *; *([" a-zA-Z0-9._/&%\/()-]+) *\))/g;
+        return /.*(field\( *"?([ a-zA-Z0-9._/&%\/()-]+)"? *; *([" a-zA-Z0-9._/&%\/()-]+(\[([1-9]\d*)\])?) *\))/g;        
     }
 
     get nameFixed(): string {

--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -102,7 +102,7 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
         let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
 
         assert.strictEqual(navObject.pageGroups.length, 2);
-        assert.strictEqual(navObject.pageFields.length, 3);
+        assert.strictEqual(navObject.pageFields.length, 5);
         navObject.pageFields.forEach(field => {
             assert.strictEqual(field.nameFixed.startsWith(testSettings[Settings.ObjectNamePrefix]), true)
         })
@@ -128,7 +128,7 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
         let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
 
         assert.strictEqual(navObject.pageGroups.length, 2);
-        assert.strictEqual(navObject.pageFields.length, 3);
+        assert.strictEqual(navObject.pageFields.length, 5);
         navObject.pageFields.forEach(field => {
             assert.strictEqual(field.nameFixed.endsWith(testSettings[Settings.ObjectNameSuffix]), true)
         })

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -228,6 +228,34 @@ export function getPageExtensionWrongFileNameWithActions(): NAVTestObject {
                     {
                         ApplicationArea = All;
                     }
+                    field(ShortcutDimCode3; ShortcutDimCode[3])
+                    {
+                        ApplicationArea = Dimensions;
+                        CaptionClass = '1,2,3';
+                        TableRelation = "Dimension Value".Code WHERE("Global Dimension No." = CONST(3),
+                                                                    "Dimension Value Type" = CONST(Standard),
+                                                                    Blocked = CONST(false));
+                        Visible = DimVisible3;
+
+                        trigger OnValidate()
+                        begin
+                            ValidateShortcutDimension(3);
+                        end;
+                    }
+                    field(ShortcutDimCode4; ShortcutDimCode[4])
+                    {
+                        ApplicationArea = Dimensions;
+                        CaptionClass = '1,2,4';
+                        TableRelation = "Dimension Value".Code WHERE("Global Dimension No." = CONST(4),
+                                                                    "Dimension Value Type" = CONST(Standard),
+                                                                    Blocked = CONST(false));
+                        Visible = DimVisible4;
+
+                        trigger OnValidate()
+                        begin
+                            ValidateShortcutDimension(4);
+                        end;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request, is trying to support Page Extensions with Array as SourceExpression.
Fixes Issue: https://github.com/waldo1001/crs-al-language-extension/issues/260
e.g.
```al
field(ShortcutDimCode4; ShortcutDimCode[4])
{
    ApplicationArea = Dimensions;
    CaptionClass = '1,2,4';
    TableRelation = "Dimension Value".Code WHERE("Global Dimension No." = CONST(4),
                                                "Dimension Value Type" = CONST(Standard),
                                                Blocked = CONST(false));
    Visible = DimVisible4;

    trigger OnValidate()
    begin
        ValidateShortcutDimension(4);
    end;
}
```