### PR TITLE
Updated snippet: teventsubwaldo 

### DIFF
--- a/snippets/fromAlExtension/al.json
+++ b/snippets/fromAlExtension/al.json
@@ -122,8 +122,8 @@
     "Snippet: Event Subscriber": {
         "prefix": "teventsubwaldo",
         "body": [
-            "[EventSubscriber(ObjectType::${1|Codeunit,Page,Query,Report,Table,XmlPort|}, ${2|Codeunit::,Database::,Page::,Query::,Report::,XmlPort::|}, ${3:'OnSomeEvent'}, ${4:'ElementName'}, ${5:SkipOnMissingLicense}, ${6:SkipOnMissingPermission})]",
-            "local procedure ${7:MyProcedure}(${8})",
+            "[EventSubscriber(ObjectType::${1|Codeunit,Page,Query,Report,Table,XmlPort|}, ${2|Codeunit::,Database::,Page::,Query::,Report::,XmlPort::|}${3}, ${4:''}, ${5:''}, ${6|false,true|}, ${7|false,true|})]",
+            "local procedure ${8:MyProcedure}(${9})",
             "begin",
             "\t$0",
             "end;"


### PR DESCRIPTION
Hello there,
whenever using this snippet, it just simply doesn't work for me: 4/5 productivity

With theses changes it's easy to TAB all the way to the procedure body (local variables still need to be added later on but thats totaly fine).

hint: if the cursor is on the 3rd, 4th and 5th step => we just press CTRL+SPACE and voilá

(just realized that we could also create some logic to insert all variables of the publisher into the event subscriber. But that's anotter story 🦦)