### PR TITLE
Minor changes to Upgrade Snippet Logic

### DIFF
--- a/snippets/install.json
+++ b/snippets/install.json
@@ -1,6 +1,6 @@
 {
     "Snippet: install codeunit": {
-        "prefix": "tinstallcodeunitwaldo",
+        "prefix": "tcinstallcodeunitwaldo",
         "description": "Snippet: Install Codeunit",
         "body": [
             "codeunit ${1:Id} ${2:Name}",
@@ -9,7 +9,6 @@
             "",
             "\ttrigger ${3|OnInstallAppPerDatabase,OnInstallAppPerCompany|}();",
             "\tvar",
-            "\t\tUpgradeTag: Codeunit \"Upgrade Tag\";",
             "\t\tmyAppInfo: ModuleInfo;",
             "\tbegin",
             "\t\tNavApp.GetCurrentModuleInfo(myAppInfo);",
@@ -18,13 +17,15 @@
             "\t\t\tHandleFreshInstall()",
             "\t\telse",
             "\t\t\tHandleReinstall();",
-            "",
-            "\t\tUpgradeTag.SetAllUpgradeTags();",
             "\tend;",
             "",
             "\tlocal procedure HandleFreshInstall();",
+            "\tvar",
+            "\t\tUpgradeTag: Codeunit \"Upgrade Tag\";",
             "\tbegin",
             "\t\t${0}",
+            "",
+            "\t\tUpgradeTag.SetAllUpgradeTags();",
             "\tend;",
             "",
             "\tlocal procedure HandleReinstall();",

--- a/snippets/install.json
+++ b/snippets/install.json
@@ -1,6 +1,6 @@
 {
     "Snippet: install codeunit": {
-        "prefix": "tcinstallcodeunitwaldo",
+        "prefix": "tinstallcodeunitwaldo",
         "description": "Snippet: Install Codeunit",
         "body": [
             "codeunit ${1:Id} ${2:Name}",

--- a/snippets/upgrade.json
+++ b/snippets/upgrade.json
@@ -1,6 +1,6 @@
 {
     "Upgrade Table Codeunit": {
-        "prefix": "tUpgradeCodeunitwaldo",
+        "prefix": "tcUpgradeCodeunitwaldo",
         "description": "Move data from obsolete table to new table",
         "body": [
             "codeunit ${1:id} \"${3:Name} Upgrade\"",
@@ -8,20 +8,19 @@
             "\tSubtype = Upgrade;",
             "",
             "\ttrigger OnUpgradePerCompany()",
+            "\tbegin",
+            "\t\t${4:Reason}();",
+            "\tend;",
+            "",
+            "\tlocal procedure ${4:Reason}()",
             "\tvar",
             "\t\tUpgradeTag: Codeunit \"Upgrade Tag\";",
             "\tbegin",
             "\t\tif UpgradeTag.HasUpgradeTag(${4:Reason}Lbl) then exit;",
             "",
-            "\t\tPerformUpgrade();",
+            "\t\t${0}",
             "",
             "\t\tUpgradeTag.SetUpgradeTag(${4:Reason}Lbl);",
-            "\tend;",
-            "",
-            "\tlocal procedure PerformUpgrade()",
-            "\tvar",
-            "\tbegin",
-            "\t\t${0}",
             "\tend;",
             "",
             "",
@@ -33,7 +32,7 @@
             "",
             "",
             "\tvar",
-            "\t\t${4:Reason}Lbl: Label '${5:CompanyName}-${4:Reason}-${CURRENT_YEAR}${CURRENT_MONTH}${CURRENT_DATE}', Locked = true;",
+            "\t\t${4:Reason}Lbl: Label '${4:Reason}-${5:ID}-${CURRENT_YEAR}${CURRENT_MONTH}${CURRENT_DATE}', Locked = true;",
             "}"
         ]
     },

--- a/snippets/upgrade.json
+++ b/snippets/upgrade.json
@@ -1,6 +1,6 @@
 {
     "Upgrade Table Codeunit": {
-        "prefix": "tcUpgradeCodeunitwaldo",
+        "prefix": "tUpgradeCodeunitwaldo",
         "description": "Move data from obsolete table to new table",
         "body": [
             "codeunit ${1:id} \"${3:Name} Upgrade\"",

--- a/snippets/upgrade.json
+++ b/snippets/upgrade.json
@@ -32,7 +32,7 @@
             "",
             "",
             "\tvar",
-            "\t\t${4:Reason}Lbl: Label '${4:Reason}-${5:ID}-${CURRENT_YEAR}${CURRENT_MONTH}${CURRENT_DATE}', Locked = true;",
+            "\t\t${4:Reason}Lbl: Label '${5:PublisherAffix}-${4:Reason}-${6:ID}-${CURRENT_YEAR}${CURRENT_MONTH}${CURRENT_DATE}', Locked = true;",
             "}"
         ]
     },


### PR DESCRIPTION
I have been using your snippets for upgrade and install codeunit a lot lately and ended up doing the sames changes all the time.
Maybe you agree with my changes and we can merge them ;)

- I usually create multiple upgrade procedures in the same upgrade codeunit, so I do the handling of the tags inside the procedure and just do a bunch of function calls in the upgrade trigger
- The HasUpgradeTag and SetUpgradeTag procedures do automatically grab the current company name, and the company name is part of the PK on the table that stores the tags. No need to included into the tag itsself
EDIT: Seems like the Company could also mean the company doing the development. So I added it back but called it "PublisherAffix"
- I only want to set the upgrade tags on install when doing a fresh install of my extension right?