### PR TITLE
Use quotes around field names that start with an integer

### DIFF
--- a/src/StringFunctions.ts
+++ b/src/StringFunctions.ts
@@ -18,7 +18,7 @@ export class StringFunctions {
             return str;
         }
 
-        if (/[^a-zA-Z0-9_]/.test(str) || /[0-9].*/.test(str) || DynamicsNAV.isKeyWord(str)) {
+        if (/[^a-zA-Z0-9_]/.test(str) || /^[0-9]/.test(str) || DynamicsNAV.isKeyWord(str)) {
             return "\"" + str + "\"";
         } else {
             return str;

--- a/src/StringFunctions.ts
+++ b/src/StringFunctions.ts
@@ -18,7 +18,7 @@ export class StringFunctions {
             return str;
         }
 
-        if (/[^a-zA-Z0-9_]/.test(str) || DynamicsNAV.isKeyWord(str)) {
+        if (/[^a-zA-Z0-9_]/.test(str) || /[0-9].*/.test(str) || DynamicsNAV.isKeyWord(str)) {
             return "\"" + str + "\"";
         } else {
             return str;

--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -268,6 +268,27 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(field.name.startsWith(testSettings[Settings.ObjectNamePrefix]), false) //does not start with prefix
         })
     });
+    test("Page - add quotations to fields/actions", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.ObjectNamePrefix] = 'waldo';
+
+        let navTestObject = NAVTestObjectLibrary.getPageWithIntegerPrefixedNames();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        // Non integer-prefixed actions and fields are not contained in double-quotes
+        assert.strictEqual(navObject.objectActions.find(a => a.name === 'Action1')
+                            .fullActionTextFixed, " action(Action1)");
+
+        assert.strictEqual(navObject.pageFields.find(a => a.name === 'Field1')
+                            .fullFieldTextFixed, "field(Field1; RandomSource)");
+
+        // Integer-prefixed actions and fields are contained in double-quotes
+        assert.strictEqual(navObject.objectActions.find(a => a.name === '2Action')
+                            .fullActionTextFixed, " action(\"2Action\")");
+
+        assert.strictEqual(navObject.pageFields.find(a => a.name === '2Field')
+                            .fullFieldTextFixed, "field(\"2Field\"; RandomSource)");
+    });
     test("Pageextension - avoid setting double prefixes to actions", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNamePrefix] = 'waldo';

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -898,6 +898,59 @@ export function getPageNoPrefixCorrectNameWithActions(): NAVTestObject {
     return object;
 }
 
+export function getPageWithIntegerPrefixedNames(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'FieldsWithIntegers.Page.al'
+    object.ObjectText = `page 50104 FieldsWithIntegers
+    {
+        PageType = Card;
+        SourceTable = test;
+
+        layout
+        {
+            area(content)
+            {
+                group(GroupName)
+                {
+                    field(Field1; RandomSource)
+                    {
+                        ApplicationArea = All;
+                    }
+                    field(2Field; RandomSource)
+                    {
+                        ApplicationArea = All;
+                    }
+                }
+            }
+        }
+
+        actions
+        {
+            area(processing)
+            {
+                action(Action1)
+                {
+                    ApplicationArea = All;
+
+                    trigger OnAction()
+                    begin
+                    end;
+                }
+                action(2Action)
+                {
+                    ApplicationArea = All;
+
+                    trigger OnAction()
+                    begin
+                    end;
+                }
+            }
+        }
+    }`
+    return object;
+}
+
 export function getObjectWithBracketsInName(): NAVTestObject {
     let object = new NAVTestObject;
 


### PR DESCRIPTION
In AL Code, it is required that any field name starting with an integer is wrapped in double quotes. If not, then the compiler throws a huge fit.

When saving a file, the CRS language extension currently removes quotes from these field names, resulting in uncompilable code. Even if using ">Save without formatting", the CRS extension still removes the quotes. This problem is described in #153 

This fix changes the `StringFunctions.encloseInQuotesIfNecessary` method to also recognize such field names and enclose them in quotation marks.