### PR TITLE
Fix issue where table field IDs get quoted if field name contains special chars

### DIFF
--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -481,6 +481,10 @@ export class NAVObject {
     }
 
     private AddPrefixAndSuffixToFields(objectText: string): string {
+        if (!/table/.test(this.objectType)) {
+            return objectText;
+        }
+
         this.tableFields.forEach(field => {
             objectText = objectText.replace(field.fullFieldText, field.fullFieldTextFixed);
         })
@@ -488,6 +492,10 @@ export class NAVObject {
         return objectText;
     }
     private AddPrefixAndSuffixToPageFields(objectText: string): string {
+        if (!/page/.test(this.objectType)) {
+            return objectText;
+        }
+
         this.pageFields.forEach(field => {
             objectText = objectText.replace(field.fullFieldText, field.fullFieldTextFixed);
         })
@@ -495,6 +503,10 @@ export class NAVObject {
         return objectText;
     }
     private AddPrefixAndSuffixToPageGroups(objectText: string): string {
+        if (!/page/.test(this.objectType)) {
+            return objectText;
+        }
+
         this.pageGroups.forEach(group => {
             objectText = objectText.replace(group.fullGroupText, group.fullGroupTextFixed);
         })
@@ -502,6 +514,10 @@ export class NAVObject {
         return objectText;
     }
     private AddPrefixAndSuffixToReportColumns(objectText: string): string {
+        if (!/report/.test(this.objectType)) {
+            return objectText;
+        }
+
         this.reportColumns.forEach(column => {
             objectText = objectText.replace(column.fullColumnText, column.fullColumnTextFixed);
         })

--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -289,6 +289,28 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
         assert.strictEqual(navObject.pageFields.find(a => a.name === '2Field')
                             .fullFieldTextFixed, "field(\"2Field\"; RandomSource)");
     });
+    test("Test - add quotations to table fields", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.ObjectNamePrefix] = 'waldo';
+
+        let navTestObject = NAVTestObjectLibrary.getTableWithIntegerPrefixedNames();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        // Non integer-prefixed actions and fields are not contained in double-quotes
+        assert.strictEqual(navObject.tableFields.find(a => a.name === 'MyField')
+                            .fullFieldTextFixed, "field(1; MyField; Integer)");
+
+        // Integer-prefixed actions and fields are contained in double-quotes
+        assert.strictEqual(navObject.tableFields.find(a => a.name === '2Field')
+                            .fullFieldTextFixed, "field(2; \"2Field\"; Integer)");
+
+        // Field with parenthesis is correctly quoted
+        assert.strictEqual(navObject.tableFields.find(a => a.name === 'With (Parenthesis)')
+                            .fullFieldTextFixed, "field(3; \"With (Parenthesis)\"; Decimal)");
+
+        // Object should be unchanged other than object prefix
+        assert.strictEqual(navTestObject.ObjectText.replace('FieldsWithIntegers', 'waldoFieldsWithIntegers'), navObject.NAVObjectTextFixed);
+    });
     test("Pageextension - avoid setting double prefixes to actions", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNamePrefix] = 'waldo';

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -951,6 +951,38 @@ export function getPageWithIntegerPrefixedNames(): NAVTestObject {
     return object;
 }
 
+export function getTableWithIntegerPrefixedNames(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'FieldsWithIntegers.Page.al'
+    object.ObjectText = `table 50104 FieldsWithIntegers
+    {
+        DataClassification = ToBeClassified;
+
+        fields
+        {
+            field(1; MyField; Integer)
+            {
+            }
+            field(2; "2Field"; Integer)
+            {
+            }
+            field(3; "With (Parenthesis)"; Decimal)
+            {
+            }
+        }
+
+        keys
+        {
+            key(PK; MyField)
+            {
+                Clustered = true;
+            }
+        }
+    }`
+    return object;
+}
+
 export function getObjectWithBracketsInName(): NAVTestObject {
     let object = new NAVTestObject;
 


### PR DESCRIPTION
#293 caused a side-effect where the ID of table fields would sometimes get wrapped in double quotes.

This change makes it so that only the relevant `AddPrefixAndSuffix` methods get called for the object type. For example, the logic to fix page fields will not get called on table objects or tableextension objects.