### PR TITLE
Add Support for AppSourceCop Setting MandatoryAffixes

### DIFF
--- a/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
+++ b/src/test/suite/NAVObject.PrefexAndSuffix.test.ts
@@ -334,6 +334,25 @@ suite("NAVObject ObjectNamePrefix Tests", () => {
             assert.strictEqual(action.name, action.nameFixed);
         })
     });
+    
+    test("Pageextension - avoid setting double affixes", () => {
+        let testSettings = Settings.GetConfigSettings(null)
+        testSettings[Settings.MandatoryAffixes] = ['waldo'];
+
+        let navTestObject = NAVTestObjectLibrary.getPageExtensionWithWaldoSuffix();
+        let navObject = new NAVObject(navTestObject.ObjectText, testSettings, navTestObject.ObjectFileName)
+
+        assert.notStrictEqual(navObject.objectActions.length, 0)
+
+        let navObject2 = new NAVObject(navObject.NAVObjectTextFixed, testSettings, navTestObject.ObjectFileName)
+        
+        assert.strictEqual(navObject2.objectName.endsWith(testSettings[Settings.MandatoryAffixes][0]), true);
+        assert.strictEqual(navObject2.objectName, navObject2.objectNameFixed)
+        navObject2.objectActions.forEach(action => {
+            assert.strictEqual(action.name.endsWith(testSettings[Settings.MandatoryAffixes][0]), true);
+            assert.strictEqual(action.name, action.nameFixed);
+        })
+    });
     test("Page - avoid removing prefixes from actions", () => {
         let testSettings = Settings.GetConfigSettings(null)
         testSettings[Settings.ObjectNamePrefix] = 'waldo';

--- a/src/test/suite/NAVTestObjectLibrary.ts
+++ b/src/test/suite/NAVTestObjectLibrary.ts
@@ -359,6 +359,57 @@ export function getPageExtensionWithWaldoPrefixWithActions(): NAVTestObject {
     return object;
 }
 
+export function getPageExtensionWithWaldoSuffix(): NAVTestObject {
+    let object = new NAVTestObject;
+
+    object.ObjectFileName = 'SomeFile.al'
+    object.ObjectText = `pageextension 50100 "Some Page Extwaldo" extends "Customer List" //22
+{
+    layout
+    {
+        addfirst(Content)
+        {
+            field("Telex No. waldo"; "Telex No.")
+            {
+                ApplicationArea = All;
+            }
+            field("Telex No. waldo"; "Telex No.")
+            {
+                ApplicationArea = All;
+            }
+            field("Telex No. waldo"; "Telex No.")
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+
+    actions
+    {
+        addfirst("&Customer")
+        {
+            action(SomeActionwaldo)
+            {
+                RunObject = page "_Empl. Absences by Cat. Matrix";
+            }
+            group(someGroupwaldo)
+            {
+                action(SomeAction2waldo)
+                {
+                    RunObject = page "_Empl. Absences by Cat. Matrix";
+                }
+                action("Some Action 3 waldo")
+                {
+                    RunObject = page "_Empl. Absences by Cat. Matrix";
+                }
+            }
+        }
+    }
+}
+    `
+    return object;
+}
+
 export function getPageExtensionWithSlashInFileName(): NAVTestObject {
     let object = new NAVTestObject;
 


### PR DESCRIPTION
Don't add affix if object name contains one of the MandatoryAffixes.

I added the affix check to then Name of the Object, the PageField and thePageAction

Fixes #279