### PR TITLE
Exclude Namespace prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ tableextension 50100 "Just Some Table Extension" extends Customer //18
 * `SkipWarningMessageOnRenameAll`: Skips the Warning when renaming all files which can disturb custom VS tasks.
 * `RenameWithGit`: Use 'git mv' to rename a file.  This keeps history of the file, but stages the rename, which you should commit separately.  **The feature is still in preview-mode, therefore the default value is 'false'**
 * `ReorganizeByNamespace`: This is a feature that allows for the automatic reorganization of files by creating folder structures based on the namespaces defined within the files.  **The feature is still in preview-mode, therefore the default value is 'false'**
+* `NamespacePrefixToIgnore`: This configuration allows you to exclude a part of Namespace during the files reorganization process based on the namespaces defined within the files.  **The feature is still in preview-mode**
 ## Skip String manipulation
 
 You can skip string manipulation by adding comments to your code:

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
                 "CRS.NamespacePrefixToIgnore": {
                     "type": "string",
                     "default": "",
-                    "description": "This configuration allows you to exclude a part of Namespace during the files reorganization process based on the namespaces defined within the files.  The feature is still in preview-mode, therefore the default value is 'false'",
+                    "description": "This configuration allows you to exclude a part of Namespace during the files reorganization process based on the namespaces defined within the files.  The feature is still in preview-mode",
                     "scope": "resource"
                 },
                 "CRS.SearchObjectNamesRegexPattern": {

--- a/package.json
+++ b/package.json
@@ -273,6 +273,12 @@
                     "description": "This is a feature that allows for the automatic reorganization of files by creating folder structures based on the namespaces defined within the files.  The feature is still in preview-mode, therefore the default value is 'false'",
                     "scope": "resource"
                 },
+                "CRS.NamespacePrefixToIgnore": {
+                    "type": "string",
+                    "default": "",
+                    "description": "This configuration allows you to exclude a part of Namespace during the files reorganization process based on the namespaces defined within the files.  The feature is still in preview-mode, therefore the default value is 'false'",
+                    "scope": "resource"
+                },
                 "CRS.SearchObjectNamesRegexPattern": {
                     "type": "string",
                     "default": "^\\w+ (\\d* )?\"*",

--- a/src/NAVObject.ts
+++ b/src/NAVObject.ts
@@ -297,6 +297,7 @@ export class NAVObject {
             this.objectType = '';
             this.objectId = '';
             this.objectName = '';
+            this.objectNamespace = '';
             this.extendedObjectName = '';
             this.extendedObjectId = '';
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -35,6 +35,7 @@ export class Settings {
     static readonly DisableCRSSnippets = 'DisableCRSSnippets';
     static readonly RenameWithGit = 'RenameWithGit';
     static readonly ReorganizeByNamespace = 'ReorganizeByNamespace';
+    static readonly NamespacePrefixToIgnore = 'NamespacePrefixToIgnore';
     static readonly Browser = 'browser';
     static readonly Incognito = 'incognito';
     static readonly packageCachePath = 'packageCachePath';
@@ -102,6 +103,7 @@ export class Settings {
         this.SettingCollection[this.PublicWebBaseUrl] = this.getSetting(this.PublicWebBaseUrl);
         this.SettingCollection[this.RenameWithGit] = this.getSetting(this.RenameWithGit);
         this.SettingCollection[this.ReorganizeByNamespace] = this.getSetting(this.ReorganizeByNamespace);
+        this.SettingCollection[this.NamespacePrefixToIgnore] = this.getSetting(this.NamespacePrefixToIgnore);
         this.SettingCollection[this.SearchObjectNamesRegexPattern] = this.getSetting(this.SearchObjectNamesRegexPattern);
         this.SettingCollection[this.DependencyGraphIncludeTestApps] = this.getSetting(this.DependencyGraphIncludeTestApps);
         this.SettingCollection[this.DependencyGraphExcludeAppNames] = this.getSetting(this.DependencyGraphExcludeAppNames);

--- a/src/WorkspaceFiles.ts
+++ b/src/WorkspaceFiles.ts
@@ -317,8 +317,15 @@ export class WorkspaceFiles {
         }
 
         if (mySettings[Settings.ReorganizeByNamespace]) {
-            let directoryPath = path.join(...navObject.objectNamespace.split("."))
-            return directoryPath
+            let directoryPath = path.join(...navObject.objectNamespace.split("."));
+
+            if (mySettings[Settings.NamespacePrefixToIgnore]) {
+                directoryPath = path.join(
+                    ...navObject.objectNamespace.replace(new RegExp(`^${mySettings[Settings.NamespacePrefixToIgnore]}\\.?`), "").split(".")
+                    );                    
+            }
+
+            return directoryPath;
         }
 
         return navObject.objectType


### PR DESCRIPTION
New setting: NamespacePrefixToIgnore
This configuration allows you to exclude a part of Namespace during the files reorganization process based on the namespaces defined within the files